### PR TITLE
fix(cypress-angular-dev-server): 🐞 resolve main file

### DIFF
--- a/packages/cypress-angular-dev-server/src/lib/create-angular-webpack-config.ts
+++ b/packages/cypress-angular-dev-server/src/lib/create-angular-webpack-config.ts
@@ -30,13 +30,12 @@ export async function createAngularWebpackConfig(config: {
       /* @hack outputPath is required, otherwise `getCommonConfig` crashes. */
       outputPath: '',
       index: null,
-      main: null,
+      /* main is required, otherwise AngularWebpackCompiler is not executed. */
+      main: getSystemPath(resolve(normalize(config.sourceRoot), normalize('main.ts'))),
+      polyfills: getSystemPath(resolve(normalize(config.sourceRoot), normalize('polyfills.ts'))),
       aot: false,
       sourceMap: true,
-      /* @hack polyfills are required, otherwise for some weird reason the produced
-       * webpack config doesn't build anything properly. */
-      polyfills: 'POLYFILL_PLACEHOLDER',
-      /* @todo dynamically import assets, styles & scripts from target's angular.json|workspace.json config. */
+      /* @todo dynamically import options from target's angular.json|workspace.json config. */
     }
   );
 


### PR DESCRIPTION
Should properly run the underlying AngularWebpackPlugin to trigger ngcc against application imports.

PS: I did not have tested it yet to see if it really skip the need to run ngcc manually. :grimacing: 