### PR TITLE
Refactor getCompilerConfig to match new Angular versions 12.1+

### DIFF
--- a/packages/cypress-angular-dev-server/src/lib/create-angular-webpack-config.ts
+++ b/packages/cypress-angular-dev-server/src/lib/create-angular-webpack-config.ts
@@ -1,4 +1,3 @@
-import { getCompilerConfig } from '@angular-devkit/build-angular/src/browser';
 import { normalizeBrowserSchema } from '@angular-devkit/build-angular/src/utils';
 import { generateWebpackConfig } from '@angular-devkit/build-angular/src/utils/webpack-browser-config';
 import {
@@ -6,9 +5,20 @@ import {
   getCommonConfig,
   getStatsConfig,
   getStylesConfig,
+  getTypeScriptConfig
 } from '@angular-devkit/build-angular/src/webpack/configs';
 import { getSystemPath, normalize, resolve } from '@angular-devkit/core';
 import { StartDevServer } from '@cypress/webpack-dev-server';
+import {WebpackConfigOptions} from "@angular-devkit/build-angular/src/utils/build-options";
+
+
+export function getCompilerConfig(wco: WebpackConfigOptions) {
+  if (wco.buildOptions.main || wco.buildOptions.polyfills) {
+    return getTypeScriptConfig(wco);
+  }
+
+  return {};
+}
 
 export async function createAngularWebpackConfig(config: {
   projectRoot: string;


### PR DESCRIPTION
I've tried to fix the problem with newer Angular 12.1 versions. getCompilerConfig does not exist anymore so I wraped the old method up