### PR TITLE
feat(cypress-mount): ✅ add support for declarations (#77)

### DIFF
--- a/packages/cypress-mount-integration/src/components/mount.spec.ts
+++ b/packages/cypress-mount-integration/src/components/mount.spec.ts
@@ -1,4 +1,6 @@
 import { mount } from '@jscutlery/cypress-mount';
+
+import { ChildComponent, ParentComponent } from '../fixtures/child-component';
 import { HelloDIComponent } from '../fixtures/hello-dependency-injection.component';
 import { HelloComponent } from '../fixtures/hello.component';
 import { AppInfo } from './../fixtures/hello-dependency-injection.component';
@@ -11,6 +13,19 @@ describe('mount', () => {
   it('should handle dependency injection', () => {
     mount(HelloDIComponent);
     cy.contains('JSCutlery');
+  });
+
+  it('should handle declarations', () => {
+    mount(
+      `<jc-parent>
+        <jc-child name="💉"></jc-child>
+      </jc-parent>`,
+      {
+        declarations: [ParentComponent, ChildComponent],
+      }
+    );
+    cy.contains('Parent');
+    cy.contains('Child 💉');
   });
 
   it('should handle providers', () => {

--- a/packages/cypress-mount-integration/src/fixtures/child-component.ts
+++ b/packages/cypress-mount-integration/src/fixtures/child-component.ts
@@ -1,0 +1,18 @@
+import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
+
+@Component({
+  selector: 'jc-child',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<h1>Child {{ name }}</h1>`,
+})
+export class ParentComponent {
+  @Input() name: string;
+}
+
+@Component({
+  selector: 'jc-parent',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<h1>Parent</h1>
+    <ng-content></ng-content>`,
+})
+export class ChildComponent {}

--- a/packages/cypress-mount/src/lib/cypress-mount.ts
+++ b/packages/cypress-mount/src/lib/cypress-mount.ts
@@ -1,20 +1,17 @@
 import '@angular/compiler';
 
-import {
-  Component,
-  NgModule,
-  PlatformRef,
-  SchemaMetadata,
-  Type,
-} from '@angular/core';
+import { Component, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { injectStylesBeforeElement, StyleOptions } from '@cypress/mount-utils';
-import type { Story } from '@storybook/angular';
 import { DynamicModule } from 'ng-dynamic-component';
+
+import type { PlatformRef, SchemaMetadata, Type } from '@angular/core';
+import type { Story } from '@storybook/angular';
 
 export interface BaseMountOptions extends Partial<StyleOptions> {
   imports?: NgModule['imports'];
+  declarations?: NgModule['declarations'];
   providers?: NgModule['providers'];
   schemas?: SchemaMetadata[];
 }
@@ -48,7 +45,6 @@ export function mountStory(
     ...options,
     inputs: args,
   });
-
 }
 
 let platformRef: PlatformRef;
@@ -143,6 +139,7 @@ export function _createContainerComponent({
 export async function _bootstrapComponent(options: {
   component: Type<unknown>;
   imports?: NgModule['imports'];
+  declarations?: NgModule['declarations'];
   providers?: NgModule['providers'];
   schemas?: SchemaMetadata[];
 }) {
@@ -158,11 +155,13 @@ export async function _bootstrapComponent(options: {
 export function _createRootModule({
   component,
   imports = [],
+  declarations = [],
   providers = [],
   schemas = [],
 }: {
   component: Type<unknown>;
   imports?: NgModule['imports'];
+  declarations?: NgModule['declarations'];
   providers?: NgModule['providers'];
   schemas?: SchemaMetadata[];
 }) {
@@ -172,7 +171,7 @@ export function _createRootModule({
    * as we want to be able to add imports dynamically. */
   const ContainerModule = NgModule({
     bootstrap: [component],
-    declarations: [component],
+    declarations: [component, ...declarations],
     imports: [BrowserModule, DynamicModule, ...imports],
     providers,
     schemas,


### PR DESCRIPTION
Allow passing a set of components, directives, and pipes that belong to the mounted module, fixes #77.