### PR TITLE
Feat: grab target build options

### DIFF
--- a/packages/cypress-angular-dev-server/src/lib/find-target-options.spec.ts
+++ b/packages/cypress-angular-dev-server/src/lib/find-target-options.spec.ts
@@ -1,0 +1,80 @@
+/* Import jest functions manually as they conflict with cypress
+ * because @cypress/webpack-dev-server references cypress types */
+import { describe, expect, it } from '@jest/globals';
+
+import { findTargetOptions } from './find-target-options';
+
+import * as fs from 'fs';
+import * as fsAsync from 'fs/promises';
+
+jest.mock('fs');
+jest.mock('fs/promises');
+
+describe('findTargetOptions', () => {
+  it('should throw if no workspace def found', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+    await expect(() => findTargetOptions('./', 'test:build')).rejects.toThrow();
+  });
+
+  it('should throw if workspace def is not JSON compliant', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+    (fsAsync.readFile as jest.Mock).mockResolvedValue(undefined);
+    await expect(() => findTargetOptions('./', 'test:build')).rejects.toThrow();
+  });
+
+  it('should return undefined if no options found in workspace def', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fsAsync.readFile as jest.Mock).mockResolvedValue('{ "version": 0 }');
+    expect(await findTargetOptions('./', 'test:build')).toBeUndefined();
+  });
+
+  it('should return target options', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fsAsync.readFile as jest.Mock).mockResolvedValue(`
+    {
+      "projects": {
+        "test": {
+          "targets": {
+            "build": {
+              "options": {
+                "value": 42
+              }
+            }
+          }
+        }
+      }
+    }
+  `);
+
+    expect(await findTargetOptions('./', 'test:build')).toEqual({ value: 42 });
+  });
+
+  it('should return target options with configuration', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fsAsync.readFile as jest.Mock).mockResolvedValue(`
+    {
+      "projects": {
+        "test": {
+          "targets": {
+            "build": {
+              "configurations": {
+                "production": {
+                  "value": 42
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `);
+
+    expect(await findTargetOptions('./', 'test:build:production')).toEqual({
+      value: 42,
+    });
+  });
+
+  it.todo('should find target for Angular CLI projects');
+
+  it.todo('should recursively find workspace def');
+});

--- a/packages/cypress-angular-dev-server/src/lib/find-target-options.spec.ts
+++ b/packages/cypress-angular-dev-server/src/lib/find-target-options.spec.ts
@@ -16,19 +16,19 @@ describe(findTargetOptions.name, () => {
 
   it('should throw if workspace def is not JSON compliant', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(false);
-    (fs.readFileSync as jest.Mock).mockResolvedValue(undefined);
+    (fs.readFileSync as jest.Mock).mockReturnValue(undefined);
     expect(() => findTargetOptions('./', 'test:build')).toThrow();
   });
 
   it('should return undefined if no options found in workspace def', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readFileSync as jest.Mock).mockResolvedValue('{ "version": 0 }');
+    (fs.readFileSync as jest.Mock).mockReturnValue('{ "version": 0 }');
     expect(findTargetOptions('./', 'test:build')).toBeUndefined();
   });
 
   it('should find target options', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readFileSync as jest.Mock).mockResolvedValue(`{
+    (fs.readFileSync as jest.Mock).mockReturnValue(`{
       "projects": {
         "test": {
           "targets": {
@@ -48,7 +48,7 @@ describe(findTargetOptions.name, () => {
 
   it('should find target options with configuration', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readFileSync as jest.Mock).mockResolvedValue(`{
+    (fs.readFileSync as jest.Mock).mockReturnValue(`{
       "projects": {
         "test": {
           "targets": {
@@ -72,7 +72,7 @@ describe(findTargetOptions.name, () => {
 
   it('should find target for Angular CLI projects', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readFileSync as jest.Mock).mockResolvedValue(`{
+    (fs.readFileSync as jest.Mock).mockReturnValue(`{
       "projects": {
         "test": {
           "architect": {
@@ -93,7 +93,7 @@ describe(findTargetOptions.name, () => {
 
   it('should find target with configuration for Angular CLI projects', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readFileSync as jest.Mock).mockResolvedValue(`{
+    (fs.readFileSync as jest.Mock).mockReturnValue(`{
       "projects": {
         "test": {
           "architect": {
@@ -116,12 +116,12 @@ describe(findTargetOptions.name, () => {
 
   it('should find target options for standalone project', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readFileSync as jest.Mock).mockResolvedValueOnce(`{
+    (fs.readFileSync as jest.Mock).mockReturnValueOnce(`{
       "projects": {
         "test": "libs/test"
       }
     }`);
-    (fs.readFileSync as jest.Mock).mockResolvedValueOnce(`{
+    (fs.readFileSync as jest.Mock).mockReturnValueOnce(`{
       "targets": {
         "build": {
           "options": {
@@ -138,12 +138,12 @@ describe(findTargetOptions.name, () => {
 
   it('should find target options with configuration for standalone project', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readFileSync as jest.Mock).mockResolvedValueOnce(`{
+    (fs.readFileSync as jest.Mock).mockReturnValueOnce(`{
       "projects": {
         "test": "libs/test"
       }
     }`);
-    (fs.readFileSync as jest.Mock).mockResolvedValueOnce(`{
+    (fs.readFileSync as jest.Mock).mockReturnValueOnce(`{
       "targets": {
         "build": {
           "configurations": {

--- a/packages/cypress-angular-dev-server/src/lib/find-target-options.spec.ts
+++ b/packages/cypress-angular-dev-server/src/lib/find-target-options.spec.ts
@@ -28,10 +28,9 @@ describe('findTargetOptions', () => {
     expect(await findTargetOptions('./', 'test:build')).toBeUndefined();
   });
 
-  it('should return target options', async () => {
+  it('should find target options', async () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fsAsync.readFile as jest.Mock).mockResolvedValue(`
-    {
+    (fsAsync.readFile as jest.Mock).mockResolvedValue(`{
       "projects": {
         "test": {
           "targets": {
@@ -49,10 +48,9 @@ describe('findTargetOptions', () => {
     expect(await findTargetOptions('./', 'test:build')).toEqual({ value: 42 });
   });
 
-  it('should return target options with configuration', async () => {
+  it('should find target options with configuration', async () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fsAsync.readFile as jest.Mock).mockResolvedValue(`
-    {
+    (fsAsync.readFile as jest.Mock).mockResolvedValue(`{
       "projects": {
         "test": {
           "targets": {
@@ -74,7 +72,95 @@ describe('findTargetOptions', () => {
     });
   });
 
-  it.todo('should find target for Angular CLI projects');
+  it('should find target for Angular CLI projects', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fsAsync.readFile as jest.Mock).mockResolvedValue(`{
+      "projects": {
+        "test": {
+          "architect": {
+            "build": {
+              "options": {
+                "value": 42
+              }
+            }
+          }
+        }
+      }
+    }`);
+
+    expect(await findTargetOptions('./', 'test:build')).toEqual({
+      value: 42,
+    });
+  });
+
+  it('should find target with configuration for Angular CLI projects', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fsAsync.readFile as jest.Mock).mockResolvedValue(`{
+      "projects": {
+        "test": {
+          "architect": {
+            "build": {
+              "configurations": {
+                "production": {
+                  "value": 42
+                }
+              }
+            }
+          }
+        }
+      }
+    }`);
+
+    expect(await findTargetOptions('./', 'test:build:production')).toEqual({
+      value: 42,
+    });
+  });
+
+  it('should find target options for standalone project', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fsAsync.readFile as jest.Mock).mockResolvedValueOnce(`{
+      "projects": {
+        "test": "libs/test"
+      }
+    }`);
+    (fsAsync.readFile as jest.Mock).mockResolvedValueOnce(`{
+      "targets": {
+        "build": {
+          "options": {
+            "value": 42
+          }
+        }
+      }
+    }`);
+
+    expect(await findTargetOptions('./', 'test:build')).toEqual({
+      value: 42,
+    });
+  });
+
+  it('should find target options with configuration for standalone project', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fsAsync.readFile as jest.Mock).mockResolvedValueOnce(`{
+      "projects": {
+        "test": "libs/test"
+      }
+    }`);
+    (fsAsync.readFile as jest.Mock).mockResolvedValueOnce(`{
+      "targets": {
+        "build": {
+          "configurations": {
+            "production": {
+              "value": 42
+            }
+          }
+        }
+      }
+    }`);
+
+    expect(await findTargetOptions('./', 'test:build:production')).toEqual({
+      value: 42,
+    });
+  });
 
   it.todo('should recursively find workspace def');
 });

--- a/packages/cypress-angular-dev-server/src/lib/find-target-options.spec.ts
+++ b/packages/cypress-angular-dev-server/src/lib/find-target-options.spec.ts
@@ -5,32 +5,30 @@ import { describe, expect, it } from '@jest/globals';
 import { findTargetOptions } from './find-target-options';
 
 import * as fs from 'fs';
-import * as fsAsync from 'fs/promises';
 
 jest.mock('fs');
-jest.mock('fs/promises');
 
-describe('findTargetOptions', () => {
-  it('should throw if no workspace def found', async () => {
+describe(findTargetOptions.name, () => {
+  it('should throw if no workspace def found', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(false);
-    await expect(() => findTargetOptions('./', 'test:build')).rejects.toThrow();
+    expect(() => findTargetOptions('./', 'test:build')).toThrow();
   });
 
-  it('should throw if workspace def is not JSON compliant', async () => {
+  it('should throw if workspace def is not JSON compliant', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(false);
-    (fsAsync.readFile as jest.Mock).mockResolvedValue(undefined);
-    await expect(() => findTargetOptions('./', 'test:build')).rejects.toThrow();
+    (fs.readFileSync as jest.Mock).mockResolvedValue(undefined);
+    expect(() => findTargetOptions('./', 'test:build')).toThrow();
   });
 
-  it('should return undefined if no options found in workspace def', async () => {
+  it('should return undefined if no options found in workspace def', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fsAsync.readFile as jest.Mock).mockResolvedValue('{ "version": 0 }');
-    expect(await findTargetOptions('./', 'test:build')).toBeUndefined();
+    (fs.readFileSync as jest.Mock).mockResolvedValue('{ "version": 0 }');
+    expect(findTargetOptions('./', 'test:build')).toBeUndefined();
   });
 
-  it('should find target options', async () => {
+  it('should find target options', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fsAsync.readFile as jest.Mock).mockResolvedValue(`{
+    (fs.readFileSync as jest.Mock).mockResolvedValue(`{
       "projects": {
         "test": {
           "targets": {
@@ -45,12 +43,12 @@ describe('findTargetOptions', () => {
     }
   `);
 
-    expect(await findTargetOptions('./', 'test:build')).toEqual({ value: 42 });
+    expect(findTargetOptions('./', 'test:build')).toEqual({ value: 42 });
   });
 
-  it('should find target options with configuration', async () => {
+  it('should find target options with configuration', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fsAsync.readFile as jest.Mock).mockResolvedValue(`{
+    (fs.readFileSync as jest.Mock).mockResolvedValue(`{
       "projects": {
         "test": {
           "targets": {
@@ -67,14 +65,14 @@ describe('findTargetOptions', () => {
     }
   `);
 
-    expect(await findTargetOptions('./', 'test:build:production')).toEqual({
+    expect(findTargetOptions('./', 'test:build:production')).toEqual({
       value: 42,
     });
   });
 
-  it('should find target for Angular CLI projects', async () => {
+  it('should find target for Angular CLI projects', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fsAsync.readFile as jest.Mock).mockResolvedValue(`{
+    (fs.readFileSync as jest.Mock).mockResolvedValue(`{
       "projects": {
         "test": {
           "architect": {
@@ -88,14 +86,14 @@ describe('findTargetOptions', () => {
       }
     }`);
 
-    expect(await findTargetOptions('./', 'test:build')).toEqual({
+    expect(findTargetOptions('./', 'test:build')).toEqual({
       value: 42,
     });
   });
 
-  it('should find target with configuration for Angular CLI projects', async () => {
+  it('should find target with configuration for Angular CLI projects', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fsAsync.readFile as jest.Mock).mockResolvedValue(`{
+    (fs.readFileSync as jest.Mock).mockResolvedValue(`{
       "projects": {
         "test": {
           "architect": {
@@ -111,19 +109,19 @@ describe('findTargetOptions', () => {
       }
     }`);
 
-    expect(await findTargetOptions('./', 'test:build:production')).toEqual({
+    expect(findTargetOptions('./', 'test:build:production')).toEqual({
       value: 42,
     });
   });
 
-  it('should find target options for standalone project', async () => {
+  it('should find target options for standalone project', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fsAsync.readFile as jest.Mock).mockResolvedValueOnce(`{
+    (fs.readFileSync as jest.Mock).mockResolvedValueOnce(`{
       "projects": {
         "test": "libs/test"
       }
     }`);
-    (fsAsync.readFile as jest.Mock).mockResolvedValueOnce(`{
+    (fs.readFileSync as jest.Mock).mockResolvedValueOnce(`{
       "targets": {
         "build": {
           "options": {
@@ -133,19 +131,19 @@ describe('findTargetOptions', () => {
       }
     }`);
 
-    expect(await findTargetOptions('./', 'test:build')).toEqual({
+    expect(findTargetOptions('./', 'test:build')).toEqual({
       value: 42,
     });
   });
 
-  it('should find target options with configuration for standalone project', async () => {
+  it('should find target options with configuration for standalone project', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fsAsync.readFile as jest.Mock).mockResolvedValueOnce(`{
+    (fs.readFileSync as jest.Mock).mockResolvedValueOnce(`{
       "projects": {
         "test": "libs/test"
       }
     }`);
-    (fsAsync.readFile as jest.Mock).mockResolvedValueOnce(`{
+    (fs.readFileSync as jest.Mock).mockResolvedValueOnce(`{
       "targets": {
         "build": {
           "configurations": {
@@ -157,7 +155,7 @@ describe('findTargetOptions', () => {
       }
     }`);
 
-    expect(await findTargetOptions('./', 'test:build:production')).toEqual({
+    expect(findTargetOptions('./', 'test:build:production')).toEqual({
       value: 42,
     });
   });

--- a/packages/cypress-angular-dev-server/src/lib/find-target-options.ts
+++ b/packages/cypress-angular-dev-server/src/lib/find-target-options.ts
@@ -1,0 +1,67 @@
+import { parseTargetString } from '@nrwl/devkit';
+import { existsSync } from 'fs';
+import { readdir, readFile } from 'fs/promises';
+import { resolve } from 'path';
+
+import type { PathLike } from 'fs';
+
+export async function findTargetOptions(
+  dir: string,
+  target: string
+): Promise<Record<string, unknown> | undefined> {
+  const workspaceDefPath = await findWorkspaceDefinition(dir);
+
+  if (workspaceDefPath == null) {
+    throw new Error(
+      'Cannot find workspace definition to load "target" options from'
+    );
+  }
+
+  const content = await readFile(workspaceDefPath, {
+    encoding: 'utf-8',
+  });
+  const workspaceDef = JSON.parse(content);
+
+  const {
+    project,
+    target: targetString,
+    configuration,
+  } = parseTargetString(target);
+
+  /* @todo: handle Angular CLI format */
+
+  if (configuration) {
+    return workspaceDef?.projects?.[project]?.targets?.[targetString]
+      ?.configurations?.[configuration];
+  }
+
+  return workspaceDef?.projects?.[project]?.targets?.[targetString]?.options;
+}
+
+async function findWorkspaceDefinition(
+  dir: PathLike,
+  recurseCount = 3
+): Promise<string | undefined> {
+  const currentDir = dir.toString();
+
+  if (existsSync(resolve(currentDir, 'workspace.json'))) {
+    return resolve(currentDir, 'workspace.json');
+  }
+
+  if (existsSync(resolve(currentDir, 'angular.json'))) {
+    return resolve(currentDir, 'angular.json');
+  }
+
+  if (recurseCount === 0) {
+    return;
+  }
+
+  for (const dirent of await readdir(resolve('../', currentDir), {
+    withFileTypes: true,
+  })) {
+    if (dirent.isDirectory()) {
+      --recurseCount;
+      await findWorkspaceDefinition(dirent.name, recurseCount);
+    }
+  }
+}

--- a/packages/cypress-angular-dev-server/src/lib/start-angular-dev-server.ts
+++ b/packages/cypress-angular-dev-server/src/lib/start-angular-dev-server.ts
@@ -1,12 +1,22 @@
 /// <reference types="cypress"/>
 import { startDevServer } from '@cypress/webpack-dev-server';
 import { merge } from 'webpack-merge';
+
 import type { Configuration } from 'webpack';
 import type { ResolvedDevServerConfig } from '@cypress/webpack-dev-server';
 
 import { createAngularWebpackConfig } from './create-angular-webpack-config';
+import { findTargetOptions } from './find-target-options';
 
 export interface CypressAngularDevServerOptions {
+  /**
+   * Load build options (like assets, scripts, polyfills, etc...) from the specified target.
+   */
+  target?: string;
+
+  /**
+   * Cypress dev server config.
+   */
   options: Cypress.DevServerConfig;
 
   /**
@@ -24,31 +34,27 @@ export interface CypressAngularDevServerOptions {
    * Cypress ts config, default to 'tsconfig.json'.
    */
   tsConfig?: string;
-
-  /**
-   * Load build options (like assets, scripts, polyfills, etc...) from the specified target.
-   */
-  target?: string;
 }
 
 export async function startAngularDevServer({
   webpackConfig,
   options,
   tsConfig = 'tsconfig.json',
-  target
+  target,
 }: CypressAngularDevServerOptions): Promise<ResolvedDevServerConfig> {
-
-
+  const buildOptions = target && findTargetOptions(__dirname, target);
   const angularWebpackConfig = await createAngularWebpackConfig({
     projectRoot: options.config.projectRoot,
     sourceRoot: options.config.componentFolder as string,
     tsConfig,
+    buildOptions,
   });
 
   return startDevServer({
     options,
-    webpackConfig: webpackConfig != null
-      ? merge(angularWebpackConfig, webpackConfig)
-      : angularWebpackConfig,
+    webpackConfig:
+      webpackConfig != null
+        ? merge(angularWebpackConfig, webpackConfig)
+        : angularWebpackConfig,
   });
 }

--- a/packages/cypress-angular-dev-server/src/lib/start-angular-dev-server.ts
+++ b/packages/cypress-angular-dev-server/src/lib/start-angular-dev-server.ts
@@ -6,20 +6,39 @@ import type { ResolvedDevServerConfig } from '@cypress/webpack-dev-server';
 
 import { createAngularWebpackConfig } from './create-angular-webpack-config';
 
-export async function startAngularDevServer({
-  webpackConfig,
-  options,
-  tsConfig = 'tsconfig.json',
-}: {
+export interface CypressAngularDevServerOptions {
+  options: Cypress.DevServerConfig;
+
+  /**
+   * Custom Webpack configuration merged with Angular CLI configuration.
+   */
   webpackConfig?: Configuration;
+
   /**
    * @deprecated config is already passed inside options.
    * @sunset 2.0.0
    */
   config?: Cypress.RuntimeConfigOptions;
-  options: Cypress.DevServerConfig;
+
+  /**
+   * Cypress ts config, default to 'tsconfig.json'.
+   */
   tsConfig?: string;
-}): Promise<ResolvedDevServerConfig> {
+
+  /**
+   * Load build options (like assets, scripts, polyfills, etc...) from the specified target.
+   */
+  target?: string;
+}
+
+export async function startAngularDevServer({
+  webpackConfig,
+  options,
+  tsConfig = 'tsconfig.json',
+  target
+}: CypressAngularDevServerOptions): Promise<ResolvedDevServerConfig> {
+
+
   const angularWebpackConfig = await createAngularWebpackConfig({
     projectRoot: options.config.projectRoot,
     sourceRoot: options.config.componentFolder as string,

--- a/packages/cypress-angular/src/generators/ng-add/ng-add.ts
+++ b/packages/cypress-angular/src/generators/ng-add/ng-add.ts
@@ -1,9 +1,6 @@
-import {
-  addDependenciesToPackageJson,
-  installPackagesTask,
-  convertNxGenerator,
-  Tree,
-} from '@nrwl/devkit';
+import { addDependenciesToPackageJson, convertNxGenerator, installPackagesTask } from '@nrwl/devkit';
+
+import type {  Tree } from '@nrwl/devkit';
 
 export async function ngAddGenerator(tree: Tree) {
   addDependenciesToPackageJson(

--- a/packages/cypress-angular/src/generators/setup-ct/files/cypress/plugins/index.ts__tmpl__
+++ b/packages/cypress-angular/src/generators/setup-ct/files/cypress/plugins/index.ts__tmpl__
@@ -2,7 +2,7 @@ import { startAngularDevServer } from '@jscutlery/cypress-angular';
 
 module.exports = (on, config) => {
   on('dev-server:start', (options) =>
-    startAngularDevServer({ options, tsConfig: 'tsconfig.cypress.json' })
+    startAngularDevServer({ options, tsConfig: 'tsconfig.cypress.json', target: '<%= target %>' })
   );
   return config;
 };

--- a/packages/cypress-angular/src/generators/setup-ct/schema.d.ts
+++ b/packages/cypress-angular/src/generators/setup-ct/schema.d.ts
@@ -1,3 +1,4 @@
 export interface SetupCtGeneratorSchema {
   project: string;
+  target?: string;
 }

--- a/packages/cypress-angular/src/generators/setup-ct/schema.json
+++ b/packages/cypress-angular/src/generators/setup-ct/schema.json
@@ -13,6 +13,10 @@
         "index": 0
       },
       "x-prompt": "Which project would you like to add Cypress Component Testing to"
+    },
+    "target": {
+      "type": "string",
+      "description": "Load build options (assets, scripts, polyfills, etc...) from a specified target, default to '<project>:build'"
     }
   },
   "required": ["project"]

--- a/packages/cypress-angular/src/generators/setup-ct/setup-ct.spec.ts
+++ b/packages/cypress-angular/src/generators/setup-ct/setup-ct.spec.ts
@@ -1,92 +1,100 @@
-import {
-  addProjectConfiguration,
-  Tree,
-  writeJson,
-  readJson,
-} from '@nrwl/devkit';
+import { addProjectConfiguration, readJson, Tree, writeJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
 import { SetupCtGeneratorSchema } from './schema';
 import { setupCtGenerator } from './setup-ct';
 
 describe('setup-ct generator', () => {
   let tree: Tree;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tree = createTreeWithEmptyWorkspace(2);
-    await setupLib();
   });
 
-  it('should add libs/my-lib/cypress/plugins/index.ts and pass tsconfig.cypress.json path to startAngularDevServer', () => {
-    const cypressPluginPath = 'libs/my-lib/cypress/plugins/index.ts';
-    expect(tree.exists(cypressPluginPath)).toBeTruthy();
-    expect(readFile(cypressPluginPath)).toContain(
-      `startAngularDevServer({ options, tsConfig: 'tsconfig.cypress.json' })`
-    );
+  describe('Target build options', () => {
+    it('configure startAngularDevServer with specified --target', async () => {
+      await setupLib({ target: 'my-app:build:production' });
+      expect(readFile('libs/my-lib/cypress/plugins/index.ts')).toContain(
+        `startAngularDevServer({ options, tsConfig: 'tsconfig.cypress.json', target: 'my-app:build:production' })`
+      );
+    });
   });
 
-  it('should add libs/my-lib/cypress/support/index.ts', () => {
-    const cypressSupportPath = 'libs/my-lib/cypress/support/index.ts';
-    expect(tree.exists(cypressSupportPath)).toBeTruthy();
-    expect(readFile(cypressSupportPath)).toContain(
-      `import '@jscutlery/cypress-angular/support';`
-    );
-  });
+  describe('Component Testing configuration', () => {
+    beforeEach(async () => await setupLib());
 
-  it('should add tsconfig.cypress.json to tsconfig.json references', () => {
-    expect(readJson(tree, 'libs/my-lib/tsconfig.json')).toEqual(
-      expect.objectContaining({
-        references: [
-          {
-            path: './tsconfig.cypress.json',
+    it('should add libs/my-lib/cypress/plugins/index.ts and configure startAngularDevServer', async () => {
+      const cypressPluginPath = 'libs/my-lib/cypress/plugins/index.ts';
+      expect(tree.exists(cypressPluginPath)).toBeTruthy();
+      expect(readFile(cypressPluginPath)).toContain(
+        `startAngularDevServer({ options, tsConfig: 'tsconfig.cypress.json', target: 'my-lib:build' })`
+      );
+    });
+
+    it('should add libs/my-lib/cypress/support/index.ts', () => {
+      const cypressSupportPath = 'libs/my-lib/cypress/support/index.ts';
+      expect(tree.exists(cypressSupportPath)).toBeTruthy();
+      expect(readFile(cypressSupportPath)).toContain(
+        `import '@jscutlery/cypress-angular/support';`
+      );
+    });
+
+    it('should add tsconfig.cypress.json to tsconfig.json references', () => {
+      expect(readJson(tree, 'libs/my-lib/tsconfig.json')).toEqual(
+        expect.objectContaining({
+          references: [
+            {
+              path: './tsconfig.cypress.json',
+            },
+          ],
+        })
+      );
+    });
+
+    it('should add libs/my-lib/cypress.json', () => {
+      const cypressConfigPath = 'libs/my-lib/cypress.json';
+      expect(tree.exists(cypressConfigPath)).toBeTruthy();
+      expect(readJson(tree, cypressConfigPath)).toEqual(
+        expect.objectContaining({
+          pluginsFile: './cypress/plugins/index.ts',
+          supportFile: './cypress/support/index.ts',
+          component: {
+            testFiles: '**/*.cy-spec.{js,ts,jsx,tsx}',
+            componentFolder: './src',
           },
-        ],
-      })
-    );
-  });
+        })
+      );
+    });
 
-  it('should add libs/my-lib/cypress.json', () => {
-    const cypressConfigPath = 'libs/my-lib/cypress.json';
-    expect(tree.exists(cypressConfigPath)).toBeTruthy();
-    expect(readJson(tree, cypressConfigPath)).toEqual(
-      expect.objectContaining({
-        pluginsFile: './cypress/plugins/index.ts',
-        supportFile: './cypress/support/index.ts',
-        component: {
-          testFiles: '**/*.cy-spec.{js,ts,jsx,tsx}',
-          componentFolder: './src',
-        },
-      })
-    );
-  });
+    it('should add libs/my-lib/tsconfig.cypress.json', () => {
+      const tsconfigPath = 'libs/my-lib/tsconfig.cypress.json';
+      expect(tree.exists(tsconfigPath)).toBeTruthy();
+      expect(readJson(tree, tsconfigPath)).toEqual(
+        expect.objectContaining({
+          extends: '../../tsconfig.base.json',
+          compilerOptions: {
+            allowSyntheticDefaultImports: true,
+            types: ['cypress'],
+          },
+          include: ['cypress/support/**/*.ts', '**/*.cy-spec.ts'],
+        })
+      );
+    });
 
-  it('should add libs/my-lib/tsconfig.cypress.json', () => {
-    const tsconfigPath = 'libs/my-lib/tsconfig.cypress.json';
-    expect(tree.exists(tsconfigPath)).toBeTruthy();
-    expect(readJson(tree, tsconfigPath)).toEqual(
-      expect.objectContaining({
-        extends: '../../tsconfig.base.json',
-        compilerOptions: {
-          allowSyntheticDefaultImports: true,
-          types: ['cypress'],
-        },
-        include: ['cypress/support/**/*.ts', '**/*.cy-spec.ts'],
-      })
-    );
-  });
-
-  it('should add "ct" executor', () => {
-    expect(
-      readJson(tree, 'workspace.json').projects['my-lib'].targets.ct
-    ).toEqual(
-      expect.objectContaining({
-        executor: '@nrwl/cypress:cypress',
-        options: {
-          cypressConfig: 'libs/my-lib/cypress.json',
-          testingType: 'component',
-          tsConfig: 'libs/my-lib/tsconfig.cypress.json',
-        },
-      })
-    );
+    it('should add "ct" executor', () => {
+      expect(
+        readJson(tree, 'workspace.json').projects['my-lib'].targets.ct
+      ).toEqual(
+        expect.objectContaining({
+          executor: '@nrwl/cypress:cypress',
+          options: {
+            cypressConfig: 'libs/my-lib/cypress.json',
+            testingType: 'component',
+            tsConfig: 'libs/my-lib/tsconfig.cypress.json',
+          },
+        })
+      );
+    });
   });
 
   describe('Workspace definition version 1', () => {
@@ -111,7 +119,7 @@ describe('setup-ct generator', () => {
     });
   });
 
-  async function setupLib() {
+  async function setupLib({ target }: { target?: string } = {}) {
     addProjectConfiguration(tree, 'my-lib', {
       root: 'libs/my-lib',
       targets: {},
@@ -121,6 +129,7 @@ describe('setup-ct generator', () => {
 
     await setupCtGenerator(tree, {
       project: 'my-lib',
+      target,
     } as SetupCtGeneratorSchema);
   }
 

--- a/packages/cypress-angular/src/generators/setup-ct/setup-ct.ts
+++ b/packages/cypress-angular/src/generators/setup-ct/setup-ct.ts
@@ -95,15 +95,22 @@ function _updateCypressTsconfig(
   }
 ) {
   const defaultBaseTsconfigPath = 'tsconfig.base.json';
-  const baseTsconfigPath = tree.exists(defaultBaseTsconfigPath)
-    ? defaultBaseTsconfigPath
-    : 'tsconfig.json';
+  let baseTsconfigPath: string;
+
+  let hasRootTsconfig = true;
+  if (tree.exists(defaultBaseTsconfigPath)) {
+    baseTsconfigPath = defaultBaseTsconfigPath;
+  } else if (tree.exists(projectRoot + '/tsconfig.app.json')) {
+    baseTsconfigPath = './tsconfig.app.json';
+    hasRootTsconfig = false;
+  } else {
+    baseTsconfigPath = 'tsconfig.json';
+  }
 
   /* Compute base tsconfig relative path. */
-  const relativeBaseTsconfig = join(
-    offsetFromRoot(projectRoot),
-    baseTsconfigPath
-  );
+  const relativeBaseTsconfig = hasRootTsconfig
+    ? join(offsetFromRoot(projectRoot), baseTsconfigPath)
+    : baseTsconfigPath;
 
   /* Make sure file exists first. */
   if (!tree.exists(cypressTsConfig)) {

--- a/packages/cypress-angular/src/generators/setup-ct/setup-ct.ts
+++ b/packages/cypress-angular/src/generators/setup-ct/setup-ct.ts
@@ -17,12 +17,13 @@ export async function setupCtGenerator(
   tree: Tree,
   options: SetupCtGeneratorSchema
 ) {
-  const { projectRoot, projectName } = _normalizeOptions(tree, options);
+  const { projectRoot, projectName, target } = _normalizeOptions(tree, options);
   const cypressTsConfigName = 'tsconfig.cypress.json';
   const cypressTsConfig = join(projectRoot, cypressTsConfigName);
 
   _addCypressFiles(tree, {
     projectRoot,
+    target,
   });
 
   _updateCypressTsconfig(tree, {
@@ -47,6 +48,7 @@ export const setupCtSchematic = convertNxGenerator(setupCtGenerator);
 interface NormalizedSchema {
   projectName: string;
   projectRoot: string;
+  target: string;
 }
 
 function _normalizeOptions(
@@ -59,6 +61,7 @@ function _normalizeOptions(
   return {
     projectName: options.project,
     projectRoot: project.root,
+    target: options.target ?? `${options.project}:build`,
   };
 }
 
@@ -67,9 +70,12 @@ function _normalizeOptions(
  */
 function _addCypressFiles(
   tree: Tree,
-  { projectRoot }: { projectRoot: string }
+  { projectRoot, target }: { projectRoot: string; target: string }
 ) {
-  generateFiles(tree, join(__dirname, './files'), projectRoot, { tmpl: '' });
+  generateFiles(tree, join(__dirname, './files'), projectRoot, {
+    tmpl: '',
+    target,
+  });
 }
 
 /**

--- a/packages/cypress-angular/src/generators/setup-ct/setup-ct.ts
+++ b/packages/cypress-angular/src/generators/setup-ct/setup-ct.ts
@@ -2,18 +2,16 @@ import {
   convertNxGenerator,
   formatFiles,
   generateFiles,
-  getWorkspacePath,
   offsetFromRoot,
-  ProjectConfiguration,
   readProjectConfiguration,
-  Tree,
   updateJson,
   updateProjectConfiguration,
-  WorkspaceJsonConfiguration,
   writeJson,
 } from '@nrwl/devkit';
 import { join } from 'path';
-import { SetupCtGeneratorSchema } from './schema';
+
+import type { Tree } from '@nrwl/devkit';
+import type { SetupCtGeneratorSchema } from './schema';
 
 export async function setupCtGenerator(
   tree: Tree,
@@ -56,34 +54,12 @@ function _normalizeOptions(
   options: SetupCtGeneratorSchema
 ): NormalizedSchema {
   const projectName = options.project;
-  const project = _readProjectConfiguration(tree, projectName);
+  const project = readProjectConfiguration(tree, projectName);
 
   return {
     projectName: options.project,
     projectRoot: project.root,
   };
-}
-
-/**
- * @hack using custom version of @nrwl/devkit's `readProjectConfiguration`
- * because `readProjectConfiguration` is not compatible with Angular CLI project
- * as nx.json is missing.
- * Cf. https://github.com/nrwl/nx/issues/5678
- */
-function _readProjectConfiguration(
-  tree: Tree,
-  projectName: string
-): ProjectConfiguration {
-  const workspace: WorkspaceJsonConfiguration = JSON.parse(
-    tree.read(getWorkspacePath(tree)).toString('utf-8')
-  );
-  const project = workspace.projects[projectName];
-
-  if (project == null) {
-    throw new Error(`Project "${projectName}" not found.`);
-  }
-
-  return project;
 }
 
 /**


### PR DESCRIPTION
Resolves #51

Current limitation: it cannot grab options from another project because Angular CLI will throw an error for files not under src directory.